### PR TITLE
Set command to manipulate options

### DIFF
--- a/src/command/export_command.rs
+++ b/src/command/export_command.rs
@@ -13,9 +13,7 @@ impl ExportCommand {
         ExportCommand {
             args,
             app: App::new("export")
-                .about(
-                    "List or export new environment variables with values.\n\nCommand alias: set",
-                )
+                .about("List or export new environment variables with values.")
                 .setting(AppSettings::NoBinaryName)
                 .setting(AppSettings::DisableVersion)
                 .arg(

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -24,6 +24,9 @@ use self::unset_command::UnsetCommand;
 pub mod export_command;
 use self::export_command::ExportCommand;
 
+pub mod set_command;
+use self::set_command::SetCommand;
+
 /// Base trait of all commands.
 pub trait Command {
     /// Execute command and return `Ok(true)` if command was run successfully, `Ok(false)` if not,
@@ -40,7 +43,8 @@ pub fn parse(program: String, args: Vec<String>) -> Box<dyn Command> {
     match program.as_ref() {
         "cd" => Box::new(CdCommand::new(args)),
         "exit" => Box::new(ExitCommand::new(args)),
-        "export" | "set" => Box::new(ExportCommand::new(args)),
+        "export" => Box::new(ExportCommand::new(args)),
+        "set" => Box::new(SetCommand::new(args)),
         "history" | "hist" | "h" => Box::new(HistoryCommand::new(args)),
         "quit" => Box::new(QuitCommand {}),
         "unset" => Box::new(UnsetCommand::new(args)),

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -61,7 +61,11 @@ pub fn execute(cmd: PromptResult, prompt: &mut Prompt) -> Option<i32> {
         },
         Err(err) => {
             if err.is::<EofError>() {
-                Some(0)
+                if prompt.context.borrow().ignoreeof {
+                    None
+                } else {
+                    Some(0)
+                }
             } else {
                 println!("{}", err);
                 None

--- a/src/command/set_command.rs
+++ b/src/command/set_command.rs
@@ -1,0 +1,118 @@
+use super::*;
+
+use clap::{App, AppSettings, Arg};
+
+/// Set command manipulates shell options.
+pub struct SetCommand {
+    args: Vec<String>,
+    app: App<'static, 'static>,
+}
+
+impl SetCommand {
+    pub fn new(args: Vec<String>) -> SetCommand {
+        SetCommand {
+            args,
+            app: App::new("set")
+                .about("Set or unset shell options.")
+                .after_help("Options currently set can be displayed via environment variable $-.")
+                .setting(AppSettings::NoBinaryName)
+                .setting(AppSettings::DisableVersion)
+                .arg(
+                    Arg::with_name("xtrace")
+                        .short("x")
+                        .help("Prints commands and their arguments when executed."),
+                )
+                .arg(
+                    Arg::with_name("option")
+                        .short("o")
+                        .long("option")
+                        .takes_value(true)
+                        .value_name("name")
+                        .help(
+                            "Sets option given option name:\n\
+                             xtrace   equivalent to -x",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("unset")
+                        .value_name("+NAME")
+                        .help("Unsets option NAME, like '+x' to unset xtrace option."),
+                ),
+        }
+    }
+
+    /// Set or unset options by adding or removing from `$-` in environment.
+    fn set(&mut self, opt: &str, enable: bool, prompt: &mut Prompt) -> Result<bool, i32> {
+        match opt {
+            "x" => {
+                let env = &mut prompt.context.borrow_mut().env;
+                if !env.contains_key("-") {
+                    env.insert(String::from("-"), String::from(""));
+                }
+
+                // Add or remove the option from $-.
+                if enable {
+                    let old_value = env[&String::from("-")].clone();
+                    if !old_value.contains(opt) {
+                        env.insert(String::from("-"), old_value + opt);
+                    }
+                } else {
+                    let old_value = env[&String::from("-")].clone();
+                    if old_value.contains(opt) {
+                        env.insert(String::from("-"), old_value.replace(opt, ""));
+                    }
+                }
+
+                // TODO: when xtrace is enabled then use it to display commands and arguments..
+            }
+            _ => {
+                println!("Unknown option: {}", opt);
+                return Ok(false);
+            }
+        }
+        return Ok(true);
+    }
+}
+
+impl Command for SetCommand {
+    fn execute(&mut self, prompt: &mut Prompt) -> Result<bool, i32> {
+        let matches = self.app.get_matches_from_safe_borrow(&self.args);
+        if let Err(err) = matches {
+            println!("{}", err);
+            return Ok(false);
+        }
+        // TODO: find better way to unwrap matches without writing like this..
+        let m = matches.unwrap();
+
+        // -x
+        if m.is_present("xtrace") {
+            return self.set("x", true, prompt);
+        }
+        // -o <name>
+        else if let Some(opt) = m.value_of("option") {
+            let opt = match opt {
+                "xtrace" => "x",
+                _ => {
+                    println!("Unknown option name: {}", opt);
+                    return Ok(false);
+                }
+            };
+            return self.set(opt, true, prompt);
+        }
+        // +<name>
+        else if let Some(opt) = m.value_of("unset") {
+            if !opt.starts_with("+") {
+                println!("Argument to unset must start with '+', Like '+x'.");
+                return Ok(false);
+            }
+            let opt = opt.get(1..).unwrap();
+            return self.set(opt, false, prompt);
+        }
+
+        Ok(true)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/command/set_command.rs
+++ b/src/command/set_command.rs
@@ -45,7 +45,9 @@ impl SetCommand {
     fn set(&mut self, opt: &str, enable: bool, prompt: &mut Prompt) -> Result<bool, i32> {
         match opt {
             "x" => {
-                let env = &mut prompt.context.borrow_mut().env;
+                let mut ctx = prompt.context.borrow_mut();
+
+                let env = &mut ctx.env;
                 if !env.contains_key("-") {
                     env.insert(String::from("-"), String::from(""));
                 }
@@ -63,7 +65,9 @@ impl SetCommand {
                     }
                 }
 
-                // TODO: when xtrace is enabled then use it to display commands and arguments..
+                if opt == "x" {
+                    ctx.xtrace = enable;
+                }
             }
             _ => {
                 println!("Unknown option: {}", opt);
@@ -177,9 +181,10 @@ mod tests {
         let mut cmd = SetCommand::new(vec!["-x".to_string()]);
         assert!(cmd.execute(&mut prompt).is_ok());
 
-        let env = &prompt.context.borrow().env;
-        assert!(env.contains_key("-"));
-        assert_eq!(env["-"], "x");
+        let ctx = prompt.context.borrow();
+        assert!(ctx.env.contains_key("-"));
+        assert_eq!(ctx.env["-"], "x");
+        assert!(ctx.xtrace);
     }
 
     #[test]
@@ -190,9 +195,10 @@ mod tests {
         let mut cmd = SetCommand::new(vec!["-o".to_string(), "xtrace".to_string()]);
         assert!(cmd.execute(&mut prompt).is_ok());
 
-        let env = &prompt.context.borrow().env;
-        assert!(env.contains_key("-"));
-        assert_eq!(env["-"], "x");
+        let ctx = prompt.context.borrow();
+        assert!(ctx.env.contains_key("-"));
+        assert_eq!(ctx.env["-"], "x");
+        assert!(ctx.xtrace);
     }
 
     #[test]
@@ -203,9 +209,10 @@ mod tests {
         let mut cmd = SetCommand::new(vec!["--option".to_string(), "xtrace".to_string()]);
         assert!(cmd.execute(&mut prompt).is_ok());
 
-        let env = &prompt.context.borrow().env;
-        assert!(env.contains_key("-"));
-        assert_eq!(env["-"], "x");
+        let ctx = prompt.context.borrow();
+        assert!(ctx.env.contains_key("-"));
+        assert_eq!(ctx.env["-"], "x");
+        assert!(ctx.xtrace);
     }
 
     #[test]
@@ -217,18 +224,20 @@ mod tests {
             let mut cmd = SetCommand::new(vec!["-x".to_string()]);
             assert!(cmd.execute(&mut prompt).is_ok());
 
-            let env = &prompt.context.borrow().env;
-            assert!(env.contains_key("-"));
-            assert_eq!(env["-"], "x");
+            let ctx = prompt.context.borrow();
+            assert!(ctx.env.contains_key("-"));
+            assert_eq!(ctx.env["-"], "x");
+            assert!(ctx.xtrace);
         }
 
         {
             let mut cmd = SetCommand::new(vec!["+x".to_string()]);
             assert!(cmd.execute(&mut prompt).is_ok());
 
-            let env = &prompt.context.borrow().env;
-            assert!(env.contains_key("-"));
-            assert_eq!(env["-"], "");
+            let ctx = prompt.context.borrow();
+            assert!(ctx.env.contains_key("-"));
+            assert_eq!(ctx.env["-"], "");
+            assert!(!ctx.xtrace);
         }
     }
 }

--- a/src/command/set_command.rs
+++ b/src/command/set_command.rs
@@ -74,7 +74,7 @@ impl SetCommand {
                 return Ok(false);
             }
         }
-        return Ok(true);
+        Ok(true)
     }
 }
 
@@ -105,7 +105,7 @@ impl Command for SetCommand {
         }
         // +<name>
         else if let Some(opt) = m.value_of("unset") {
-            if !opt.starts_with("+") || opt.len() == 1 {
+            if !opt.starts_with('+') || opt.len() == 1 {
                 println!(
                     "Argument to unset must start with '+' with a non-empty string following, \
                      Like '+x'."

--- a/src/command/set_command.rs
+++ b/src/command/set_command.rs
@@ -43,12 +43,13 @@ impl SetCommand {
                         .value_name("name")
                         .help(
                             "Sets option given option name:\n\
-                             xtrace   equivalent to -x\n\
-                             errexit  equivalent to -e\n\
-                             verbose  equivalent to -v (verbose level 1)\n\
+                             xtrace     equivalent to -x\n\
+                             errexit    equivalent to -e\n\
+                             verbose    equivalent to -v (verbose level 1)\n\
                              \n\
-                             emacs    edit mode\n\
-                             vi       edit mode",
+                             emacs      edit mode\n\
+                             vi         edit mode\n\
+                             ignoreeof  Don't exit shell when reading EOF",
                         ),
                 )
                 .arg(
@@ -137,6 +138,10 @@ impl Command for SetCommand {
                 }
                 "vi" => {
                     prompt.editor.set_edit_mode(EditMode::Vi);
+                    return Ok(true);
+                }
+                "ignoreeof" => {
+                    prompt.context.borrow_mut().ignoreeof = true;
                     return Ok(true);
                 }
                 _ => {
@@ -431,5 +436,17 @@ mod tests {
 
         let ctx = prompt.context.borrow();
         assert_eq!(ctx.verbose, 0);
+    }
+
+    #[test]
+    fn set_ignoreeof() {
+        let mut prompt = Prompt::create(context::default());
+        prompt.context.borrow_mut().ignoreeof = false;
+
+        let mut cmd = SetCommand::new(vec!["-o".to_string(), "ignoreeof".to_string()]);
+        assert!(cmd.execute(&mut prompt).is_ok());
+
+        let ctx = prompt.context.borrow();
+        assert!(ctx.ignoreeof);
     }
 }

--- a/src/command/set_command.rs
+++ b/src/command/set_command.rs
@@ -17,7 +17,28 @@ impl SetCommand {
             args,
             app: App::new("set")
                 .about("Set or unset shell options.")
-                .after_help("Options currently set can be displayed via environment variable $-.")
+                .after_help(
+                    r#"ENVIRONMENT:
+
+  Options currently set can be displayed via environment variable $-.
+  Note that it only applies to options with a shorthand form, like 'x' for xtrace.
+
+EXAMPLES:
+
+  Set xtrace option:
+    set -x
+    set -o xtrace
+    set --option xtrace
+
+  Set Emacs edit mode:
+    set -o emacs
+    set --option emacs
+
+  Unset errexit mode:
+    set +e
+    set +o errexit
+    set +option errexit"#,
+                )
                 .setting(AppSettings::NoBinaryName)
                 .setting(AppSettings::DisableVersion)
                 .arg(
@@ -42,14 +63,14 @@ impl SetCommand {
                         .takes_value(true)
                         .value_name("name")
                         .help(
-                            "Sets option given option name:\n\
-                             xtrace     equivalent to -x\n\
-                             errexit    equivalent to -e\n\
-                             verbose    equivalent to -v (verbose level 1)\n\
-                             \n\
-                             emacs      edit mode\n\
-                             vi         edit mode\n\
-                             ignoreeof  Don't exit shell when reading EOF",
+                            r#"Sets option given option name:
+  xtrace     equivalent to -x
+  errexit    equivalent to -e
+  verbose    equivalent to -v (verbose level 1)
+
+  emacs      edit mode
+  vi         edit mode
+  ignoreeof  Don't exit shell when reading EOF"#,
                         ),
                 )
                 .arg(Arg::with_name("unset").value_name("+NAME").help(

--- a/src/context.rs
+++ b/src/context.rs
@@ -24,6 +24,10 @@ pub struct ContextData {
 
     /// Extra trace option (set via `set -x`) outputs command trace to stdout.
     pub xtrace: bool,
+
+    /// Whether or not to exit shell immediately if a command exit with non-zero status
+    /// (set via `set -e`).
+    pub errexit: bool,
 }
 
 impl ContextData {
@@ -33,6 +37,7 @@ impl ContextData {
             config: Config::new(config_path),
             env: env::vars().collect(),
             xtrace: false,
+            errexit: false,
         }
     }
 }
@@ -44,6 +49,7 @@ impl Default for ContextData {
             config: Config::default(),
             env: HashMap::new(),
             xtrace: false,
+            errexit: false,
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -21,6 +21,9 @@ pub struct ContextData {
 
     /// Environment passed to newly spawned processes.
     pub env: HashMap<String, String>,
+
+    /// Extra trace option (set via `set -x`) outputs command trace to stdout.
+    pub xtrace: bool,
 }
 
 impl ContextData {
@@ -29,6 +32,7 @@ impl ContextData {
             verbose,
             config: Config::new(config_path),
             env: env::vars().collect(),
+            xtrace: false,
         }
     }
 }
@@ -39,6 +43,7 @@ impl Default for ContextData {
             verbose: 0,
             config: Config::default(),
             env: HashMap::new(),
+            xtrace: false,
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -28,6 +28,9 @@ pub struct ContextData {
     /// Whether or not to exit shell immediately if a command exit with non-zero status
     /// (set via `set -e`).
     pub errexit: bool,
+
+    /// Whether or not to not exit shell when reading EOF.
+    pub ignoreeof: bool,
 }
 
 impl ContextData {
@@ -38,6 +41,7 @@ impl ContextData {
             env: env::vars().collect(),
             xtrace: false,
             errexit: false,
+            ignoreeof: false,
         }
     }
 }
@@ -50,6 +54,7 @@ impl Default for ContextData {
             env: HashMap::new(),
             xtrace: false,
             errexit: false,
+            ignoreeof: false,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,8 @@ pub mod editor;
 pub mod prompt;
 pub mod util;
 
-use crate::command::set_command::SetCommand;
-use crate::command::Command;
 use crate::prompt::Prompt;
+use crate::util::append_value_for_key;
 
 use clap::ArgMatches;
 
@@ -64,8 +63,7 @@ pub fn repl(arg_matches: &ArgMatches) -> i32 {
 
     // Append "v" to $- if verbose is set. This compliments the set command.
     if verbose_level > 0 {
-        let mut cmd = SetCommand::new(vec!["-v".to_string(); verbose_level as usize]);
-        assert!(cmd.execute(&mut prompt).unwrap());
+        append_value_for_key("v", "-", &mut prompt.context.borrow_mut().env);
     }
 
     // If -c <command> is specified then run command and exit.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,8 @@ pub mod editor;
 pub mod prompt;
 pub mod util;
 
+use crate::command::set_command::SetCommand;
+use crate::command::Command;
 use crate::prompt::Prompt;
 
 use clap::ArgMatches;
@@ -56,11 +58,15 @@ pub fn repl(arg_matches: &ArgMatches) -> i32 {
         return 1;
     }
 
-    let context = context::new(
-        arg_matches.occurrences_of("verbose"),
-        arg_matches.value_of("config"),
-    );
+    let verbose_level = arg_matches.occurrences_of("verbose");
+    let context = context::new(verbose_level, arg_matches.value_of("config"));
     let mut prompt = Prompt::new(context);
+
+    // Append "v" to $- if verbose is set. This compliments the set command.
+    if verbose_level > 0 {
+        let mut cmd = SetCommand::new(vec!["-v".to_string(); verbose_level as usize]);
+        assert!(cmd.execute(&mut prompt).unwrap());
+    }
 
     // If -c <command> is specified then run command and exit.
     if let Some(command) = arg_matches.value_of("command") {

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -183,6 +183,11 @@ impl Prompt {
             program = "cd".to_string();
         }
 
+        // Show fully expanded command program and arguments with xtrace option enabled.
+        if self.context.borrow().xtrace {
+            println!("+carapace> {} {}", program, args.join(" "));
+        }
+
         Ok(command::parse(program, args))
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,10 +7,10 @@ use std::collections::HashMap;
 lazy_static! {
     static ref WORD_REGEX: Regex = Regex::new(r"(\w+)").unwrap();
     static ref GLOB_REGEX: Regex = Regex::new(r"(([\w\d.\\/\.]*\*[\w\d.\\/\.]*)+)").unwrap();
-    static ref ENV_VAR_REGEX: Regex = Regex::new(r"(\$[\w\?#!\$_@\*]*)").unwrap();
-    static ref BRACKET_ENV_VAR_REGEX: Regex = Regex::new(r"(\$\{([\w\?#!\$_@\*]+)\})").unwrap();
+    static ref ENV_VAR_REGEX: Regex = Regex::new(r"(\$[\w\?\-#!\$_@\*]*)").unwrap();
+    static ref BRACKET_ENV_VAR_REGEX: Regex = Regex::new(r"(\$\{([\w\?\-#!\$_@\*]+)\})").unwrap();
     static ref PARTIAL_BRACKET_ENV_VAR_REGEX: Regex =
-        Regex::new(r"(\$\{([\w\?#!\$_@\*]*)\}?)").unwrap();
+        Regex::new(r"(\$\{([\w\?\-#!\$_@\*]*)\}?)").unwrap();
 }
 
 /// Check if `pos`ition is within first word in `text`.
@@ -240,6 +240,11 @@ mod tests {
     }
 
     #[test]
+    fn env_var_at_pos_dollar_dash() {
+        assert_eq!(env_var_at_pos(6, "hello $- and universe"), "$-");
+    }
+
+    #[test]
     fn bracket_env_var_at_pos_start() {
         assert_eq!(env_var_at_pos(6, "hello ${world} and universe"), "${world}");
     }
@@ -293,8 +298,13 @@ mod tests {
     }
 
     #[test]
-    fn partial_env_var_at_pos_only_dollar_sign_and_bracket() {
+    fn partial_env_var_at_pos_only_dollar_sign_bracket() {
         assert_eq!(partial_env_var_at_pos(6, "hello ${  and universe"), "${");
+    }
+
+    #[test]
+    fn partial_env_var_at_pos_only_dollar_sign_bracket_dash() {
+        assert_eq!(partial_env_var_at_pos(6, "hello ${-  and universe"), "${-");
     }
 
     #[test]


### PR DESCRIPTION
This is the second evolution of the `set` builtin to act more like other shells.

Run `set --help` for more information but in general, the following options can be used:
- `xtrace` (`-x`) - Prints commands and their arguments when executed
- `errexit` (`-e`) - Exit shell if a command yields non-zero exit code
- `verbose` (`-v`) - Sets verbosity level. Can be used multiple times, like `-v -v -v` or `-vvv` for a verbosity level of 3. With >=1 the shell prints input lines as they are read
- `emacs` - Sets Emacs edit mode
- `vi` - Set Vi edit mode
- `ignoreeof` - Don't exit shell when reading EOF

All options with a shorthand (`-x`, `-e`, `-v`) will be present in `$-` when enabled.