### PR TITLE
Implemented Env class and moved utility functionality into it

### DIFF
--- a/src/command/cd_command.rs
+++ b/src/command/cd_command.rs
@@ -74,6 +74,12 @@ impl Command for CdCommand {
     }
 }
 
+impl CommandAliases for CdCommand {
+    fn aliases() -> Vec<String> {
+        vec!["cd".to_string()]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/command/exit_command.rs
+++ b/src/command/exit_command.rs
@@ -54,6 +54,12 @@ impl Command for ExitCommand {
     }
 }
 
+impl CommandAliases for ExitCommand {
+    fn aliases() -> Vec<String> {
+        vec!["exit".to_string()]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/command/export_command.rs
+++ b/src/command/export_command.rs
@@ -34,7 +34,7 @@ impl Command for ExportCommand {
         }
 
         if self.args.is_empty() {
-            prompt.context.borrow().env.print();
+            print!("{}", prompt.context.borrow().env);
         } else {
             for var in &self.args {
                 let (k, v) = match var.find('=') {

--- a/src/command/export_command.rs
+++ b/src/command/export_command.rs
@@ -51,3 +51,9 @@ impl Command for ExportCommand {
         self
     }
 }
+
+impl CommandAliases for ExportCommand {
+    fn aliases() -> Vec<String> {
+        vec!["export".to_string()]
+    }
+}

--- a/src/command/export_command.rs
+++ b/src/command/export_command.rs
@@ -34,12 +34,7 @@ impl Command for ExportCommand {
         }
 
         if self.args.is_empty() {
-            let ctx = prompt.context.borrow();
-            let mut keys: Vec<&String> = ctx.env.keys().peekable().collect();
-            keys.sort();
-            for k in &keys {
-                println!("{}={}", k, ctx.env[*k]);
-            }
+            prompt.context.borrow().env.print();
         } else {
             for var in &self.args {
                 let (k, v) = match var.find('=') {

--- a/src/command/general_command.rs
+++ b/src/command/general_command.rs
@@ -20,7 +20,7 @@ impl Command for GeneralCommand {
         let output = process::Command::new(&self.program)
             .args(&self.args)
             .env_clear()
-            .envs(&ctx.env)
+            .envs(ctx.env.as_ref())
             // Inherit stdout/stderr so it is displayed with the shell, including term colors.
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())

--- a/src/command/history_command.rs
+++ b/src/command/history_command.rs
@@ -59,3 +59,13 @@ impl Command for HistoryCommand {
         self
     }
 }
+
+impl CommandAliases for HistoryCommand {
+    fn aliases() -> Vec<String> {
+        // NOTE: The order is very important!
+        vec!["h", "hist", "history"]
+            .into_iter()
+            .map(|x| x.to_string())
+            .collect()
+    }
+}

--- a/src/command/quit_command.rs
+++ b/src/command/quit_command.rs
@@ -12,3 +12,9 @@ impl Command for QuitCommand {
         self
     }
 }
+
+impl CommandAliases for QuitCommand {
+    fn aliases() -> Vec<String> {
+        vec!["quit".to_string()]
+    }
+}

--- a/src/command/set_command.rs
+++ b/src/command/set_command.rs
@@ -1,7 +1,5 @@
 use super::*;
 
-use crate::util::{append_value_for_key, replace_value_for_key};
-
 use clap::{App, AppSettings, Arg};
 
 use rustyline::config::Configurer;
@@ -96,9 +94,9 @@ EXAMPLES:
                 // Add or remove the option from $-.
                 let env = &mut ctx.env;
                 if enable {
-                    append_value_for_key(opt, "-", env);
+                    env.append("-", opt.to_string());
                 } else {
-                    replace_value_for_key(opt, "", "-", env);
+                    env.replace("-", opt.to_string(), "".to_string());
                 }
 
                 if opt == "x" {
@@ -139,7 +137,7 @@ impl Command for SetCommand {
         // -v..
         else if m.is_present("verbose") {
             let mut ctx = prompt.context.borrow_mut();
-            append_value_for_key("v", "-", &mut ctx.env);
+            ctx.env.append("-", "v".to_string());
 
             let level = m.occurrences_of("verbose");
             ctx.verbose = level;

--- a/src/command/set_command.rs
+++ b/src/command/set_command.rs
@@ -220,6 +220,12 @@ impl Command for SetCommand {
     }
 }
 
+impl CommandAliases for SetCommand {
+    fn aliases() -> Vec<String> {
+        vec!["set".to_string()]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/command/unset_command.rs
+++ b/src/command/unset_command.rs
@@ -39,3 +39,9 @@ impl Command for UnsetCommand {
         self
     }
 }
+
+impl CommandAliases for UnsetCommand {
+    fn aliases() -> Vec<String> {
+        vec!["unset".to_string()]
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,9 +1,8 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
-use std::env;
 use std::rc::Rc;
 
 use crate::config::Config;
+use crate::env::Env;
 
 pub type Context = Rc<RefCell<ContextData>>;
 
@@ -20,7 +19,7 @@ pub struct ContextData {
     pub config: Config,
 
     /// Environment passed to newly spawned processes.
-    pub env: HashMap<String, String>,
+    pub env: Env,
 
     /// Extra trace option (set via `set -x`) outputs command trace to stdout.
     pub xtrace: bool,
@@ -38,7 +37,7 @@ impl ContextData {
         ContextData {
             verbose,
             config: Config::new(config_path),
-            env: env::vars().collect(),
+            env: Env::new(),
             xtrace: false,
             errexit: false,
             ignoreeof: false,
@@ -51,7 +50,7 @@ impl Default for ContextData {
         ContextData {
             verbose: 0,
             config: Config::default(),
-            env: HashMap::new(),
+            env: Env::default(),
             xtrace: false,
             errexit: false,
             ignoreeof: false,

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -4,6 +4,7 @@ use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
 use rustyline::{Config, Editor, Helper};
 
+use crate::command;
 use crate::context::Context;
 use crate::env::Env;
 use crate::util;
@@ -41,12 +42,8 @@ impl EditorHelper {
     }
 
     fn builtin_command_completer(&self, line: &str, pos: usize) -> Vec<Pair> {
-        let mut builtins: Vec<String> = vec![
-            "cd", "exit", "export", "h", "hist", "history", "quit", "set", "unset",
-        ]
-        .into_iter()
-        .map(|x| x.to_string())
-        .collect();
+        // Start with builtin commands.
+        let mut builtins = command::builtins();
 
         // Add aliases, if any.
         let config = &self.context.borrow().config;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -91,7 +91,7 @@ impl EditorHelper {
             return candidates;
         }
 
-        for k in self.context.borrow().env.keys() {
+        for k in self.context.borrow().env.as_ref().keys() {
             let lookfor = format!("${}", k);
             let lookfor2 = format!("${{{}", k);
 
@@ -189,9 +189,8 @@ impl Helper for EditorHelper {}
 mod tests {
     use super::*;
 
-    use std::collections::HashMap;
-
     use crate::context;
+    use crate::env::Env;
 
     macro_rules! create_test_editor {
         ($e:ident) => {
@@ -312,7 +311,7 @@ mod tests {
 
     #[test]
     fn env_var_completer_normal_var() {
-        let mut env = HashMap::new();
+        let mut env = Env::default();
         env.insert("HELLO".to_string(), "WORLD".to_string());
         create_test_editor_with_env!(editor; env);
 
@@ -324,7 +323,7 @@ mod tests {
 
     #[test]
     fn env_var_completer_multiple_values() {
-        let mut env = HashMap::new();
+        let mut env = Env::default();
         env.insert("HELLO".to_string(), "0".to_string());
         env.insert("HEY".to_string(), "1".to_string());
         env.insert("HAND".to_string(), "2".to_string());
@@ -359,7 +358,7 @@ mod tests {
 
     #[test]
     fn env_var_completer_bracket_var() {
-        let mut env = HashMap::new();
+        let mut env = Env::default();
         env.insert("HELLO".to_string(), "WORLD".to_string());
         create_test_editor_with_env!(editor; env);
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -5,6 +5,7 @@ use rustyline::hint::Hinter;
 use rustyline::{Config, Editor, Helper};
 
 use crate::context::Context;
+use crate::env::Env;
 use crate::util;
 
 /// Creates `Editor` instance with proper config and completion.
@@ -86,7 +87,7 @@ impl EditorHelper {
     fn env_var_completer(&self, line: &str, pos: usize) -> Vec<Pair> {
         let mut candidates = Vec::new();
 
-        let word = util::partial_env_var_at_pos(pos, line);
+        let word = Env::partial_var_at_pos(pos, line);
         if word.is_empty() {
             return candidates;
         }

--- a/src/env.rs
+++ b/src/env.rs
@@ -7,6 +7,9 @@ use std::ops::Index;
 
 lazy_static! {
     static ref ENV_VAR_REGEX: Regex = Regex::new(r"(\$[\w\?\-#!\$_@\*]*)").unwrap();
+    static ref PARTIAL_BRACKET_ENV_VAR_REGEX: Regex =
+        Regex::new(r"(\$\{([\w\?\-#!\$_@\*]*)\}?)").unwrap();
+    static ref BRACKET_ENV_VAR_REGEX: Regex = Regex::new(r"(\$\{([\w\?\-#!\$_@\*]+)\})").unwrap();
 }
 
 type Key = String;
@@ -122,6 +125,50 @@ impl Env {
                 .into_owned();
         }
         res
+    }
+
+    // TODO: -> Option<String>
+    /// Returns environment variable at position in text.
+    pub fn var_at_pos(pos: usize, text: &str) -> Value {
+        assert!(pos <= text.len());
+        for cap in BRACKET_ENV_VAR_REGEX.captures_iter(text) {
+            let cap0 = cap.get(0).unwrap();
+            let cap1 = cap.get(1);
+            if pos >= cap0.start() && pos <= cap0.end() {
+                if let Some(cap1_val) = cap1 {
+                    return cap1_val.as_str().to_string();
+                }
+            }
+        }
+        for cap in ENV_VAR_REGEX.captures_iter(text) {
+            let cap = cap.get(0).unwrap();
+            if pos >= cap.start() && pos <= cap.end() {
+                return cap.as_str().to_string();
+            }
+        }
+        "".to_string()
+    }
+
+    // TODO: return Option<Value>
+    /// Returns partial environment variable at position in text.
+    pub fn partial_var_at_pos(pos: usize, text: &str) -> Value {
+        assert!(pos <= text.len());
+        for cap in PARTIAL_BRACKET_ENV_VAR_REGEX.captures_iter(text) {
+            let cap0 = cap.get(0).unwrap();
+            let cap1 = cap.get(1);
+            if pos >= cap0.start() && pos <= cap0.end() {
+                if let Some(cap1_val) = cap1 {
+                    return cap1_val.as_str().to_string();
+                }
+            }
+        }
+        for cap in ENV_VAR_REGEX.captures_iter(text) {
+            let cap = cap.get(0).unwrap();
+            if pos >= cap.start() && pos <= cap.end() {
+                return cap.as_str().to_string();
+            }
+        }
+        "".to_string()
     }
 }
 
@@ -309,5 +356,111 @@ mod tests {
         env.insert("USERNAME".to_string(), "foobar".to_string());
         let output = env.replace_vars(&input);
         assert_eq!(output, "foobar".to_string());
+    }
+
+    #[test]
+    fn partial_env_var_at_pos_start() {
+        assert_eq!(
+            Env::partial_var_at_pos(6, "hello ${world and universe"),
+            "${world"
+        );
+    }
+
+    #[test]
+    fn partial_env_var_at_pos_middle() {
+        assert_eq!(
+            Env::partial_var_at_pos(9, "hello ${world and universe"),
+            "${world"
+        );
+    }
+
+    #[test]
+    fn partial_env_var_at_pos_end() {
+        assert_eq!(
+            Env::partial_var_at_pos(12, "hello ${world and universe"),
+            "${world"
+        );
+    }
+
+    #[test]
+    fn partial_env_var_at_pos_can_yield_full_match() {
+        assert_eq!(
+            Env::partial_var_at_pos(9, "hello ${world} and universe"),
+            "${world}"
+        );
+    }
+
+    #[test]
+    fn partial_env_var_at_pos_only_dollar_sign_bracket() {
+        assert_eq!(Env::partial_var_at_pos(6, "hello ${  and universe"), "${");
+    }
+
+    #[test]
+    fn partial_env_var_at_pos_only_dollar_sign_bracket_dash() {
+        assert_eq!(Env::partial_var_at_pos(6, "hello ${-  and universe"), "${-");
+    }
+
+    #[test]
+    fn env_var_at_pos_beginning() {
+        assert_eq!(Env::var_at_pos(0, "$hello world and universe"), "$hello");
+    }
+
+    #[test]
+    fn env_var_at_pos_start() {
+        assert_eq!(Env::var_at_pos(6, "hello $world and universe"), "$world");
+    }
+
+    #[test]
+    fn env_var_at_pos_middle() {
+        assert_eq!(Env::var_at_pos(2, "$hello world and universe"), "$hello");
+    }
+
+    #[test]
+    fn env_var_at_pos_end() {
+        assert_eq!(Env::var_at_pos(11, "hello $world and universe"), "$world");
+    }
+
+    #[test]
+    fn env_var_at_pos_right_after() {
+        assert_eq!(Env::var_at_pos(12, "hello $world and universe"), "$world");
+    }
+
+    #[test]
+    fn env_var_at_pos_after() {
+        assert_eq!(Env::var_at_pos(13, "hello $world  and universe"), "");
+    }
+
+    #[test]
+    fn env_var_at_pos_only_dollar_sign() {
+        assert_eq!(Env::var_at_pos(6, "hello $  and universe"), "$");
+    }
+
+    #[test]
+    fn env_var_at_pos_dollar_dash() {
+        assert_eq!(Env::var_at_pos(6, "hello $- and universe"), "$-");
+    }
+
+    #[test]
+    fn bracket_env_var_at_pos_start() {
+        assert_eq!(
+            Env::var_at_pos(6, "hello ${world} and universe"),
+            "${world}"
+        );
+    }
+
+    #[test]
+    fn bracket_env_var_at_pos_middle() {
+        assert_eq!(
+            Env::var_at_pos(10, "hello ${world} and universe"),
+            "${world}"
+        );
+    }
+
+    #[test]
+    fn bracket_env_var_at_pos_end() {
+        assert_eq!(
+            Env::var_at_pos(13, "hello ${world} and universe"),
+            "${world}"
+        );
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -2,6 +2,7 @@ use regex::{Captures, Regex};
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::env;
+use std::fmt::{Display, Formatter, Result};
 use std::hash::Hash;
 use std::ops::Index;
 
@@ -90,14 +91,6 @@ impl Env {
         }
     }
 
-    pub fn print(&self) {
-        let mut keys: Vec<&Key> = self.env.keys().peekable().collect();
-        keys.sort();
-        for k in &keys {
-            println!("{}={}", k, self.env[*k]);
-        }
-    }
-
     /// Replaces all environment variables in \p data and returns resulting string.
     pub fn replace_vars<S>(&self, data: &S) -> Value
     where
@@ -175,6 +168,17 @@ impl Default for Env {
         Env {
             env: HashMap::new(),
         }
+    }
+}
+
+impl Display for Env {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let mut keys: Vec<&Key> = self.env.keys().peekable().collect();
+        keys.sort();
+        for k in &keys {
+            writeln!(f, "{}={}", k, self.env[*k])?;
+        }
+        Ok(())
     }
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,0 +1,313 @@
+use regex::{Captures, Regex};
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::env;
+use std::hash::Hash;
+use std::ops::Index;
+
+lazy_static! {
+    static ref ENV_VAR_REGEX: Regex = Regex::new(r"(\$[\w\?\-#!\$_@\*]*)").unwrap();
+}
+
+type Key = String;
+type Value = String;
+type Map = HashMap<Key, Value>;
+
+/// Env encapsulates environment variables and their manipulation.
+pub struct Env {
+    env: Map,
+}
+
+impl Env {
+    pub fn new() -> Env {
+        Env {
+            env: env::vars().collect(),
+        }
+    }
+
+    pub fn insert(&mut self, key: Key, value: Value) {
+        self.env.insert(key, value);
+    }
+
+    pub fn remove<S>(&mut self, key: &S)
+    where
+        S: ?Sized + Hash + Eq,
+        Key: Borrow<S>,
+    {
+        self.env.remove(key);
+    }
+
+    pub fn get<S>(&self, key: &S) -> Option<&Value>
+    where
+        S: ?Sized + Hash + Eq,
+        Key: Borrow<S>,
+    {
+        self.env.get(key)
+    }
+
+    pub fn contains_key<S>(&self, key: &S) -> bool
+    where
+        S: ?Sized + Hash + Eq,
+        Key: Borrow<S>,
+    {
+        self.env.contains_key(key)
+    }
+
+    /// Append value to value at key but only if current value doesn't already contain input value.
+    /** If key doesn't exist then an empty string entry will be created. */
+    pub fn append<S>(&mut self, key: &S, value: Value)
+    where
+        S: ?Sized + Hash + Eq + ToString,
+        Key: Borrow<S>,
+    {
+        if !self.env.contains_key(key) {
+            self.env.insert(key.to_string(), "".to_string());
+        }
+        let old_value = self.env[&key].clone();
+        if !old_value.contains(&value) {
+            self.env.insert(key.to_string(), old_value + &value);
+        }
+    }
+
+    /// Replace value with another value for value at key but only if current value already is
+    /// contained.
+    /** If key doesn't exist then an empty string entry will be created. */
+    pub fn replace<S>(&mut self, key: &S, old_value: Value, new_value: Value)
+    where
+        S: ?Sized + Hash + Eq + ToString,
+        Key: Borrow<S>,
+    {
+        if !self.env.contains_key(key) {
+            self.env.insert(key.to_string(), "".to_string());
+        }
+        let value = self.env[key].clone();
+        if value.contains(&old_value) {
+            self.env
+                .insert(key.to_string(), value.replace(&old_value, &new_value));
+        }
+    }
+
+    pub fn print(&self) {
+        let mut keys: Vec<&Key> = self.env.keys().peekable().collect();
+        keys.sort();
+        for k in &keys {
+            println!("{}={}", k, self.env[*k]);
+        }
+    }
+
+    /// Replaces all environment variables in \p data and returns resulting string.
+    pub fn replace_vars<S>(&self, data: &S) -> Value
+    where
+        S: ?Sized + Hash + Eq + ToString,
+        Key: Borrow<S>,
+    {
+        let mut res = data.to_string();
+        for (k, v) in &self.env {
+            // Bracketed version always replaces.
+            res = res.replace(&format!("${{{}}}", k), &v);
+
+            // Non-bracketed version can only replace when complete subset of string. For instance,
+            // "$USER" must not replace in "$USERNAME" but "$USERNAME" can since it's the complete
+            // string.
+            let lookfor = format!("${}", k);
+            res = ENV_VAR_REGEX
+                .replace_all(&res, |caps: &Captures| {
+                    let m = caps.get(0).unwrap().as_str();
+                    if m == lookfor {
+                        v.to_string()
+                    } else {
+                        m.to_string()
+                    }
+                })
+                .into_owned();
+        }
+        res
+    }
+}
+
+impl Default for Env {
+    fn default() -> Env {
+        Env {
+            env: HashMap::new(),
+        }
+    }
+}
+
+impl<S> Index<&S> for Env
+where
+    S: ?Sized + Hash + Eq,
+    Key: Borrow<S>,
+{
+    type Output = Value;
+
+    fn index(&self, key: &S) -> &Self::Output {
+        &self.env[key]
+    }
+}
+
+impl AsRef<Map> for Env {
+    fn as_ref(&self) -> &Map {
+        &self.env
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_with_current_vars() {
+        assert_eq!(Env::new().env, env::vars().collect());
+    }
+
+    #[test]
+    fn default_is_empty() {
+        let env = Env::default();
+        assert!(env.env.is_empty());
+    }
+
+    #[test]
+    fn as_ref() {
+        let mut env = Env::default();
+        env.insert("foo".to_string(), "bar".to_string());
+        env.insert("baz".to_string(), "taz".to_string());
+        assert_eq!(*env.as_ref(), env.env);
+        assert_eq!(2, env.as_ref().len());
+    }
+
+    #[test]
+    fn insert() {
+        let mut env = Env::default();
+        assert!(!env.contains_key("a"));
+        env.insert("a".to_string(), "b".to_string());
+        assert!(env.contains_key("a"));
+        assert_eq!(env["a"], "b");
+    }
+
+    #[test]
+    fn remove() {
+        let mut env = Env::default();
+        env.insert("a".to_string(), "b".to_string());
+        assert!(env.contains_key("a"));
+        env.remove("a");
+        assert!(!env.contains_key("a"));
+    }
+
+    #[test]
+    fn get() {
+        let mut env = Env::default();
+        env.insert("a".to_string(), "b".to_string());
+        assert_eq!(env.get("a"), Some(&"b".to_string()));
+        assert_eq!(env.get("b"), None);
+    }
+
+    #[test]
+    fn contains_key() {
+        let mut env = Env::default();
+        assert!(!env.env.contains_key("a"));
+        assert!(!env.contains_key("a"));
+        env.insert("a".to_string(), "b".to_string());
+        assert!(env.env.contains_key("a"));
+        assert!(env.contains_key("a"));
+    }
+
+    #[test]
+    fn append_value_for_key_with_no_value() {
+        let mut env = Env::default();
+        env.append("foo", "a".to_string());
+        assert!(env.contains_key("foo"));
+        assert_eq!("a", env["foo"]);
+    }
+
+    #[test]
+    fn append_value_for_key_with_prior_value() {
+        let mut env = Env::default();
+        env.insert("foo".to_string(), "a".to_string());
+        env.append("foo", "b".to_string());
+        assert!(env.contains_key("foo"));
+        assert_eq!("ab", env["foo"]);
+    }
+
+    #[test]
+    fn dont_append_value_for_key_if_value_exits() {
+        let mut env = Env::default();
+        env.insert("foo".to_string(), "a".to_string());
+        env.append("foo", "a".to_string());
+        assert!(env.contains_key("foo"));
+        assert_eq!("a", env["foo"]);
+    }
+
+    #[test]
+    fn replace_value_for_key_with_no_value() {
+        let mut env = Env::default();
+        env.replace("foo", "a".to_string(), "b".to_string());
+        assert!(env.contains_key("foo"));
+        assert_eq!("", env["foo"]);
+    }
+
+    #[test]
+    fn replace_value_for_key_with_prior_value() {
+        let mut env = Env::default();
+        env.insert("foo".to_string(), "a".to_string());
+        env.replace("foo", "a".to_string(), "b".to_string());
+        assert!(env.contains_key("foo"));
+        assert_eq!("b", env["foo"]);
+    }
+
+    #[test]
+    fn dont_replace_value_for_key_if_value_doesnt_exists() {
+        let mut env = Env::default();
+        env.replace("foo", "a".to_string(), "b".to_string());
+        assert!(env.contains_key("foo"));
+        assert_eq!("", env["foo"]);
+    }
+
+    #[test]
+    fn replace_vars_general() {
+        let input = String::from("$ONE, ${TWO}, $ONE, $THREE");
+        let mut env = Env::default();
+        env.insert("ONE".to_string(), "1".to_string());
+        env.insert("TWO".to_string(), "2".to_string());
+        let output = env.replace_vars(&input);
+        assert_eq!(output, "1, 2, 1, $THREE".to_string());
+    }
+
+    #[test]
+    fn replace_vars_dont_when_subset() {
+        let input = String::from("$USERNAME");
+        let mut env = Env::default();
+        env.insert("USER".to_string(), "test".to_string());
+        let output = env.replace_vars(&input);
+
+        // $USERNAME is not present and $USER is subset of $USERNAME, so don't replace!
+        assert_eq!(output, "$USERNAME".to_string());
+    }
+
+    #[test]
+    fn replace_vars_do_when_last() {
+        let input = String::from("$USER");
+        let mut env = Env::default();
+        env.insert("USER".to_string(), "test".to_string());
+        let output = env.replace_vars(&input);
+        assert_eq!(output, "test".to_string());
+    }
+
+    #[test]
+    fn replace_vars_do_when_subset_when_bracketed() {
+        let input = String::from("${USER}NAME");
+        let mut env = Env::default();
+        env.insert("USER".to_string(), "test".to_string());
+        let output = env.replace_vars(&input);
+        assert_eq!(output, "testNAME".to_string());
+    }
+
+    #[test]
+    fn replace_vars_use_longest_match() {
+        let input = String::from("$USERNAME");
+        let mut env = Env::default();
+        env.insert("USER".to_string(), "test".to_string());
+        env.insert("USERNAME".to_string(), "foobar".to_string());
+        let output = env.replace_vars(&input);
+        assert_eq!(output, "foobar".to_string());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,11 @@ pub mod command;
 pub mod config;
 pub mod context;
 pub mod editor;
+pub mod env;
 pub mod prompt;
 pub mod util;
 
 use crate::prompt::Prompt;
-use crate::util::append_value_for_key;
 
 use clap::ArgMatches;
 
@@ -63,7 +63,7 @@ pub fn repl(arg_matches: &ArgMatches) -> i32 {
 
     // Append "v" to $- if verbose is set. This compliments the set command.
     if verbose_level > 0 {
-        append_value_for_key("v", "-", &mut prompt.context.borrow_mut().env);
+        prompt.context.borrow_mut().env.append("-", "v".to_string());
     }
 
     // If -c <command> is specified then run command and exit.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 use glob::glob;
 use json::JsonValue;
-use regex::{Captures, Regex};
+use regex::Regex;
 
 use std::collections::HashMap;
 
@@ -107,33 +107,6 @@ pub fn json_obj_to_hash_map(obj: &JsonValue) -> HashMap<String, String> {
     map
 }
 
-pub fn replace_vars<S: ::std::hash::BuildHasher>(
-    data: &str,
-    map: &HashMap<String, String, S>,
-) -> String {
-    let mut res = data.to_string();
-    for (k, v) in map {
-        // Bracketed version always replaces.
-        res = res.replace(&format!("${{{}}}", k), v);
-
-        // Non-bracketed version can only replace when complete subset of string. For instance,
-        // "$USER" must not replace in "$USERNAME" but "$USERNAME" can since it's the complete
-        // string.
-        let lookfor = format!("${}", k);
-        res = ENV_VAR_REGEX
-            .replace_all(&res, |caps: &Captures| {
-                let m = caps.get(0).unwrap().as_str();
-                if m == lookfor {
-                    v.to_string()
-                } else {
-                    m.to_string()
-                }
-            })
-            .into_owned();
-    }
-    res
-}
-
 pub fn expand_glob(input: &str) -> Vec<String> {
     let mut res = Vec::new();
     for path in glob(input).unwrap().filter_map(Result::ok) {
@@ -143,40 +116,6 @@ pub fn expand_glob(input: &str) -> Vec<String> {
         res.push(input.to_string());
     }
     res
-}
-
-/// Append value to value at key but only if current value doesn't already contain input value.
-/** If key doesn't exist then an empty string entry will be created. */
-pub fn append_value_for_key<S: ::std::hash::BuildHasher>(
-    append: &str,
-    key: &str,
-    map: &mut HashMap<String, String, S>,
-) {
-    if !map.contains_key(key) {
-        map.insert(key.to_string(), "".to_string());
-    }
-    let old_value = map[key].clone();
-    if !old_value.contains(append) {
-        map.insert(key.to_string(), old_value + append);
-    }
-}
-
-/// Replace value with another value for value at key but only if current value already is
-/// contained.
-/** If key doesn't exist then an empty string entry will be created. */
-pub fn replace_value_for_key<S: ::std::hash::BuildHasher>(
-    replace: &str,
-    with: &str,
-    key: &str,
-    map: &mut HashMap<String, String, S>,
-) {
-    if !map.contains_key(key) {
-        map.insert(key.to_string(), "".to_string());
-    }
-    let old_value = map[key].clone();
-    if old_value.contains(replace) {
-        map.insert(key.to_string(), old_value.replace(replace, with));
-    }
 }
 
 #[cfg(test)]
@@ -374,105 +313,5 @@ mod tests {
         assert_eq!(map.get("two"), Some(&"2".to_string()));
         assert!(map.contains_key("three"));
         assert_eq!(map.get("three"), Some(&"3".to_string()));
-    }
-
-    #[test]
-    fn replace_vars_general() {
-        let input = String::from("$ONE, ${TWO}, $ONE, $THREE");
-        let mut vars = HashMap::new();
-        vars.insert("ONE".to_string(), "1".to_string());
-        vars.insert("TWO".to_string(), "2".to_string());
-        let output = replace_vars(&input, &vars);
-        assert_eq!(output, "1, 2, 1, $THREE".to_string());
-    }
-
-    #[test]
-    fn replace_vars_dont_when_subset() {
-        let input = String::from("$USERNAME");
-        let mut vars = HashMap::new();
-        vars.insert("USER".to_string(), "test".to_string());
-        let output = replace_vars(&input, &vars);
-
-        // $USERNAME is not present and $USER is subset of $USERNAME, so don't replace!
-        assert_eq!(output, "$USERNAME".to_string());
-    }
-
-    #[test]
-    fn replace_vars_do_when_last() {
-        let input = String::from("$USER");
-        let mut vars = HashMap::new();
-        vars.insert("USER".to_string(), "test".to_string());
-        let output = replace_vars(&input, &vars);
-        assert_eq!(output, "test".to_string());
-    }
-
-    #[test]
-    fn replace_vars_do_when_subset_when_bracketed() {
-        let input = String::from("${USER}NAME");
-        let mut vars = HashMap::new();
-        vars.insert("USER".to_string(), "test".to_string());
-        let output = replace_vars(&input, &vars);
-        assert_eq!(output, "testNAME".to_string());
-    }
-
-    #[test]
-    fn replace_vars_use_longest_match() {
-        let input = String::from("$USERNAME");
-        let mut vars = HashMap::new();
-        vars.insert("USER".to_string(), "test".to_string());
-        vars.insert("USERNAME".to_string(), "foobar".to_string());
-        let output = replace_vars(&input, &vars);
-        assert_eq!(output, "foobar".to_string());
-    }
-
-    #[test]
-    fn append_value_for_key_with_no_value() {
-        let env = &mut HashMap::new();
-        append_value_for_key("a", "foo", env);
-        assert!(env.contains_key("foo"));
-        assert_eq!("a", env["foo"]);
-    }
-
-    #[test]
-    fn append_value_for_key_with_prior_value() {
-        let env = &mut HashMap::new();
-        env.insert("foo".to_string(), "a".to_string());
-        append_value_for_key("b", "foo", env);
-        assert!(env.contains_key("foo"));
-        assert_eq!("ab", env["foo"]);
-    }
-
-    #[test]
-    fn dont_append_value_for_key_if_value_exits() {
-        let env = &mut HashMap::new();
-        env.insert("foo".to_string(), "a".to_string());
-        append_value_for_key("a", "foo", env);
-        assert!(env.contains_key("foo"));
-        assert_eq!("a", env["foo"]);
-    }
-
-    #[test]
-    fn replace_value_for_key_with_no_value() {
-        let env = &mut HashMap::new();
-        replace_value_for_key("a", "b", "foo", env);
-        assert!(env.contains_key("foo"));
-        assert_eq!("", env["foo"]);
-    }
-
-    #[test]
-    fn replace_value_for_key_with_prior_value() {
-        let env = &mut HashMap::new();
-        env.insert("foo".to_string(), "a".to_string());
-        replace_value_for_key("a", "b", "foo", env);
-        assert!(env.contains_key("foo"));
-        assert_eq!("b", env["foo"]);
-    }
-
-    #[test]
-    fn dont_replace_value_for_key_if_value_doesnt_exists() {
-        let env = &mut HashMap::new();
-        replace_value_for_key("a", "b", "foo", env);
-        assert!(env.contains_key("foo"));
-        assert_eq!("", env["foo"]);
     }
 }


### PR DESCRIPTION
Instead of accessing a `HashMap<String, String>` directly, the `Env` class has the functions needed while keeping encapsulation.

`util::{replace_vars, append_value_for_key, replace_value_for_key}` were moved into `Env` but with slightly shorter function names.